### PR TITLE
Correct action tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Read
-        uses: katydecorah/read-action@3.0.0
+        uses: katydecorah/read-action@v3.0.0
       - name: Download the book thumbnail
         run: curl "${{ env.BookThumb }}" -o "img/staging/${{ env.BookThumbOutput }}"
       - name: Commit files


### PR DESCRIPTION
Thank you for releasing this repository! :bow: 

I was taking your action for a spin and I discovered I had to use the `v3.0.0` tag instead of `3.0.0`. I hope this will help others in the future.