### PR TITLE
Support adding books when the read file is empty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17114,7 +17114,7 @@ function toJson(fileName) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const contents = (yield returnReadFile(fileName));
-            return load(contents);
+            return load(contents) || [];
         }
         catch (error) {
             (0,core.setFailed)(error.message);

--- a/src/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/__tests__/__snapshots__/utils.test.js.snap
@@ -189,6 +189,43 @@ Array [
 ]
 `;
 
+exports[`addBook works, empty file 1`] = `
+Array [
+  Object {
+    "authors": Array [
+      "Yaa Gyasi",
+    ],
+    "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
+    "categories": Array [
+      "Fiction",
+    ],
+    "dateFinished": "2020-09-12",
+    "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
+    "imageLinks": Object {
+      "smallThumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+      "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+    },
+    "industryIdentifiers": Array [
+      Object {
+        "identifier": "0525658181",
+        "type": "ISBN_10",
+      },
+      Object {
+        "identifier": "9780525658184",
+        "type": "ISBN_13",
+      },
+    ],
+    "isbn": "0525658181",
+    "language": "en",
+    "notes": "Brilliant!",
+    "pageCount": 288,
+    "printType": "BOOK",
+    "publishedDate": "2020",
+    "title": "Transcendent Kingdom",
+  },
+]
+`;
+
 exports[`addBook works, no images 1`] = `
 Array [
   Object {

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -93,6 +93,22 @@ describe("addBook", () => {
       "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
     );
   });
+
+  test("works, empty file", async () => {
+    jest.spyOn(promises, "readFile").mockResolvedValueOnce("");
+    expect(
+      await addBook(
+        {
+          date,
+          body: "Brilliant!",
+          bookIsbn: "0525658181",
+        },
+
+        book,
+        "_data/read.yml"
+      )
+    ).toMatchSnapshot();
+  });
 });
 
 it("toYaml", async () => {

--- a/src/docs.mjs
+++ b/src/docs.mjs
@@ -25,7 +25,7 @@ let yml = readFileSync("./.github/workflows/read.yml", "utf8");
 // TODO: clean this up!
 writeDocs(
   `\`\`\`yml
-${yml.replace("uses: ./", `uses: katydecorah/read-action@${version}`)}
+${yml.replace("uses: ./", `uses: katydecorah/read-action@v${version}`)}
 \`\`\`
 `,
   "SETUP"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,7 +129,7 @@ export const addBook = async (
 export async function toJson(fileName: string) {
   try {
     const contents = (await returnReadFile(fileName)) as string;
-    return load(contents);
+    return load(contents) || [];
   } catch (error) {
     setFailed(error.message);
   }


### PR DESCRIPTION
Hi :wave:! It's me again. Sorry to bug you a _second_ time. I really should have waited to make #16 until after I got everything working...

I created my read file, `_data/read.yml`, and the action couldn't add the first book I read :scream:! It turns out that [`load("")` returns `undefined`](https://github.com/katydecorah/read-action/blob/3962f544e16dc8d13216bab9feea8a50b9ff6821/src/utils.ts#L132) and JavaScript can't call `.push` on `undefined`. This PR modifies `toJson` to account for this.

I added a unit test and did my best to follow the existing style. Additionally, I included a second [commit](75a415695ded508c2d24a13d6c01f8d9efcda235) that I should have included in #16. Forgive me. I was young and naïve.

Please let me know if I did something wrong and I will do my best to remedy it.