### PR TITLE
Prune metadata (removal and renaming)

### DIFF
--- a/_data/read.json
+++ b/_data/read.json
@@ -6,18 +6,11 @@
     "authors": ["Raven Leilani"],
     "publishedDate": "2020-08-04",
     "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
-    "industryIdentifiers": [
-      { "type": "ISBN_10", "identifier": "0385696000" },
-      { "type": "ISBN_13", "identifier": "9780385696005" }
-    ],
     "pageCount": 240,
     "printType": "BOOK",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
-    },
+    "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "language": "en",
-    "canonicalVolumeLink": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ"
+    "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ"
   },
   {
     "isbn": "9780374719760",
@@ -26,19 +19,12 @@
     "authors": ["Anna Wiener"],
     "publishedDate": "2020-01-14",
     "description": "One of Vogue''s 22 Books to Read This Winter \"A definitive document of a world in transition: I won''t be alone in returning to Uncanny Valley for clarity and consolation for many years to come.\" —Jia Tolentino, author of Trick Mirror: Reflections on Self-Delusion The prescient, page-turning account of a journey in Silicon Valley: a defining memoir of our digital age In her mid-twenties, at the height of tech industry idealism, Anna Wiener—stuck, broke, and looking for meaning in her work, like any good millennial--left a job in book publishing for the promise of the new digital economy. She moved from New York to San Francisco, where she landed at a big-data startup in the heart of the Silicon Valley bubble: a world of surreal extravagance, dubious success, and fresh-faced entrepreneurs hell-bent on domination, glory, and, of course, progress. Anna arrived amidst a massive cultural shift, as the tech industry rapidly transformed into a locus of wealth and power rivaling Wall Street. But amid the company ski vacations and in-office speakeasies, boyish camaraderie and ride-or-die corporate fealty, a new Silicon Valley began to emerge: one in far over its head, one that enriched itself at the expense of the idyllic future it claimed to be building. Part coming-age-story, part portrait of an already-bygone era, Anna Wiener’s memoir is a rare first-person glimpse into high-flying, reckless startup culture at a time of unchecked ambition, unregulated surveillance, wild fortune, and accelerating political power. With wit, candor, and heart, Anna deftly charts the tech industry’s shift from self-appointed world savior to democracy-endangering liability, alongside a personal narrative of aspiration, ambivalence, and disillusionment. Unsparing and incisive, Uncanny Valley is a cautionary tale, and a revelatory interrogation of a world reckoning with consequences its unwitting designers are only beginning to understand.",
-    "industryIdentifiers": [
-      { "type": "ISBN_13", "identifier": "9780374719760" },
-      { "type": "ISBN_10", "identifier": "0374719764" }
-    ],
     "pageCount": 288,
     "printType": "BOOK",
     "categories": ["Biography & Autobiography"],
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
-    },
+    "thumbnail": "https://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "language": "en",
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ"
+    "link": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ"
   },
   {
     "isbn": "9780399181146",
@@ -47,19 +33,12 @@
     "authors": ["Kimberly Drew", "Jenna Wortham"],
     "publishedDate": "2020-12-01",
     "description": "NEW YORK TIMES EDITORS’ CHOICE • An archive of collective memory and exuberant testimony A luminous map to navigate an opaque and disorienting present An infinite geography of possible futures What does it mean to be Black and alive right now? Kimberly Drew and Jenna Wortham have brought together this collection of work—images, photos, essays, memes, dialogues, recipes, tweets, poetry, and more—to tell the story of the radical, imaginative, provocative, and gorgeous world that Black creators are bringing forth today. The book presents a succession of startling and beautiful pieces that generate an entrancing rhythm: Readers will go from conversations with activists and academics to memes and Instagram posts, from powerful essays to dazzling paintings and insightful infographics. In answering the question of what it means to be Black and alive, Black Futures opens a prismatic vision of possibility for every reader.",
-    "industryIdentifiers": [
-      { "type": "ISBN_13", "identifier": "9780399181146" },
-      { "type": "ISBN_10", "identifier": "0399181148" }
-    ],
     "pageCount": 544,
     "printType": "BOOK",
     "categories": ["Social Science"],
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
-    },
+    "thumbnail": "https://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "language": "en",
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ"
+    "link": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ"
   },
   {
     "isbn": "9780525620792",
@@ -68,19 +47,12 @@
     "authors": ["Silvia Moreno-Garcia"],
     "publishedDate": "2020-06-30",
     "description": "NEW YORK TIMES BESTSELLER • “It’s Lovecraft meets the Brontës in Latin America, and after a slow-burn start Mexican Gothic gets seriously weird.”—The Guardian IN DEVELOPMENT AS A HULU ORIGINAL LIMITED SERIES PRODUCED BY KELLY RIPA AND MARK CONSUELOS • FINALIST FOR THE LOCUS AWARD • NOMINATED FOR THE BRAM STOKER AWARD • NAMED ONE OF THE BEST BOOKS OF THE YEAR BY The New Yorker • Vanity Fair • NPR • The Washington Post • Tordotcom • Marie Claire • Vox • Mashable • Men’s Health • Library Journal • Book Riot • LibraryReads An isolated mansion. A chillingly charismatic aristocrat. And a brave socialite drawn to expose their treacherous secrets. . . . From the author of Gods of Jade and Shadow comes “a terrifying twist on classic gothic horror” (Kirkus Reviews) set in glamorous 1950s Mexico. After receiving a frantic letter from her newly-wed cousin begging for someone to save her from a mysterious doom, Noemí Taboada heads to High Place, a distant house in the Mexican countryside. She’s not sure what she will find—her cousin’s husband, a handsome Englishman, is a stranger, and Noemí knows little about the region. Noemí is also an unlikely rescuer: She’s a glamorous debutante, and her chic gowns and perfect red lipstick are more suited for cocktail parties than amateur sleuthing. But she’s also tough and smart, with an indomitable will, and she is not afraid: Not of her cousin’s new husband, who is both menacing and alluring; not of his father, the ancient patriarch who seems to be fascinated by Noemí; and not even of the house itself, which begins to invade Noemi’s dreams with visions of blood and doom. Her only ally in this inhospitable abode is the family’s youngest son. Shy and gentle, he seems to want to help Noemí, but might also be hiding dark knowledge of his family’s past. For there are many secrets behind the walls of High Place. The family’s once colossal wealth and faded mining empire kept them from prying eyes, but as Noemí digs deeper she unearths stories of violence and madness. And Noemí, mesmerized by the terrifying yet seductive world of High Place, may soon find it impossible to ever leave this enigmatic house behind. “It’s as if a supernatural power compels us to turn the pages of the gripping Mexican Gothic.”—The Washington Post “Mexican Gothic is the perfect summer horror read, and marks Moreno-Garcia with her hypnotic and engaging prose as one of the genre’s most exciting talents.”—Nerdist “A period thriller as rich in suspense as it is in lush ’50s atmosphere.”—Entertainment Weekly",
-    "industryIdentifiers": [
-      { "type": "ISBN_13", "identifier": "9780525620792" },
-      { "type": "ISBN_10", "identifier": "0525620796" }
-    ],
     "pageCount": 320,
     "printType": "BOOK",
     "categories": ["Fiction"],
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
-    },
+    "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "language": "en",
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ"
+    "link": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ"
   },
   {
     "isbn": "9781317588610",
@@ -89,19 +61,12 @@
     "authors": ["bell hooks"],
     "publishedDate": "2014-12-17",
     "description": "A classic work of feminist scholarship, Ain't I a Woman has become a must-read for all those interested in the nature of black womanhood. Examining the impact of sexism on black women during slavery, the devaluation of black womanhood, black male sexism, racism among feminists, and the black woman's involvement with feminism, hooks attempts to move us beyond racist and sexist assumptions. The result is nothing short of groundbreaking, giving this book a critical place on every feminist scholar's bookshelf.",
-    "industryIdentifiers": [
-      { "type": "ISBN_13", "identifier": "9781317588610" },
-      { "type": "ISBN_10", "identifier": "1317588614" }
-    ],
     "pageCount": 206,
     "printType": "BOOK",
     "categories": ["Social Science"],
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
-    },
+    "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "language": "en",
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ"
+    "link": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ"
   },
   {
     "isbn": "9780525511342",
@@ -110,18 +75,11 @@
     "authors": ["Kali Fajardo-Anstine"],
     "publishedDate": "2022-06-07",
     "description": "NATIONAL BESTSELLER • A dazzling epic of betrayal, love, and fate that spans five generations of an Indigenous Chicano family in the American West, from the author of the National Book Award finalist Sabrina & Corina A Phenomenal Book Club Pick • “Sometimes you just step into a book and let it wash over you, like you’re swimming under a big, sparkling night sky.”—Celeste Ng, author of Little Fires Everywhere and Everything I Never Told You ONE OF THE MOST ANTICIPATED BOOKS OF 2022—The Millions, Electric Lit, Lit Hub, Book Riot There is one every generation, a seer who keeps the stories. Luz “Little Light” Lopez, a tea leaf reader and laundress, is left to fend for herself after her older brother, Diego, a snake charmer and factory worker, is run out of town by a violent white mob. As Luz navigates 1930s Denver, she begins to have visions that transport her to her Indigenous homeland in the nearby Lost Territory. Luz recollects her ancestors’ origins, how her family flourished, and how they were threatened. She bears witness to the sinister forces that have devastated her people and their homelands for generations. In the end, it is up to Luz to save her family stories from disappearing into oblivion. Written in Kali Fajardo-Anstine’s singular voice, the wildly entertaining and complex lives of the Lopez family fill the pages of this multigenerational western saga. Woman of Light is a transfixing novel about survival, family secrets, and love—filled with an unforgettable cast of characters, all of whom are just as special, memorable, and complicated as our beloved heroine, Luz.",
-    "industryIdentifiers": [
-      { "type": "ISBN_13", "identifier": "9780525511342" },
-      { "type": "ISBN_10", "identifier": "0525511342" }
-    ],
     "pageCount": 336,
     "printType": "BOOK",
     "categories": ["Fiction"],
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
-    },
+    "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "language": "en",
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ"
+    "link": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ"
   }
 ]

--- a/dist/index.js
+++ b/dist/index.js
@@ -14204,20 +14204,15 @@ function removeWrappedQuotes(str) {
 
 function cleanBook(options, book) {
     const { notes, bookIsbn, dateFinished } = options;
-    return Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({ isbn: bookIsbn, dateFinished: dateFinished || new Date().toISOString().slice(0, 10) }, (notes && { notes })), ("title" in book && { title: book.title })), ("authors" in book && {
+    return Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({ isbn: bookIsbn, dateFinished: dateFinished || new Date().toISOString().slice(0, 10) }, (notes && { notes })), ("title" in book && { title: book.title })), ("authors" in book && {
         authors: book.authors,
     })), ("publishedDate" in book && { publishedDate: book.publishedDate })), ("description" in book && {
         description: removeWrappedQuotes(book.description),
-    })), ("industryIdentifiers" in book && {
-        industryIdentifiers: book.industryIdentifiers,
-    })), ("pageCount" in book && { pageCount: book.pageCount })), ("printType" in book && { printType: book.printType })), ("categories" in book && { categories: book.categories })), ("imageLinks" in book && {
-        imageLinks: Object.assign(Object.assign({}, ("smallThumbnail" in book.imageLinks && {
-            smallThumbnail: book.imageLinks.smallThumbnail.replace("http:", "https:"),
-        })), ("thumbnail" in book.imageLinks && {
-            thumbnail: book.imageLinks.thumbnail.replace("http:", "https:"),
-        })),
+    })), ("pageCount" in book && { pageCount: book.pageCount })), ("printType" in book && { printType: book.printType })), ("categories" in book && { categories: book.categories })), ("imageLinks" in book &&
+        "thumbnail" in book.imageLinks && {
+        thumbnail: book.imageLinks.thumbnail.replace("http:", "https:"),
     })), ("language" in book && { language: book.language })), ("canonicalVolumeLink" in book && {
-        canonicalVolumeLink: book.canonicalVolumeLink,
+        link: book.canonicalVolumeLink,
     }));
 }
 
@@ -14266,9 +14261,9 @@ function addBook(options, book, fileName) {
         // clean up book data
         const newBook = cleanBook(options, book);
         // export book thumbnail to download later
-        if (newBook.imageLinks && newBook.imageLinks.thumbnail) {
+        if (newBook.thumbnail) {
             (0,core.exportVariable)("BookThumbOutput", `book-${newBook.isbn}.png`);
-            (0,core.exportVariable)("BookThumb", newBook.imageLinks.thumbnail);
+            (0,core.exportVariable)("BookThumb", newBook.thumbnail);
         }
         // append new book
         readListJson.push(newBook);

--- a/src/__tests__/__snapshots__/add-book.test.ts.snap
+++ b/src/__tests__/__snapshots__/add-book.test.ts.snap
@@ -6,91 +6,52 @@ exports[`addBook works 1`] = `
     "authors": [
       "Raven Leilani",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
     "dateFinished": "2020-09-06",
     "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "0385696000",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780385696005",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "9780385696005",
     "language": "en",
+    "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
     "pageCount": 240,
     "printType": "BOOK",
     "publishedDate": "2020-08-04",
+    "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "title": "Luster",
   },
   {
     "authors": [
       "Yaa Gyasi",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2020-09-12",
     "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "0525658181",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780525658184",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "0525658181",
     "language": "en",
+    "link": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "notes": "Amazing!",
     "pageCount": 288,
     "printType": "BOOK",
     "publishedDate": "2020",
+    "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "title": "Transcendent Kingdom",
   },
   {
     "authors": [
       "Anna Wiener",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ",
     "categories": [
       "Biography & Autobiography",
     ],
     "dateFinished": "2020-11-22",
     "description": "One of Vogue''s 22 Books to Read This Winter "A definitive document of a world in transition: I won''t be alone in returning to Uncanny Valley for clarity and consolation for many years to come." —Jia Tolentino, author of Trick Mirror: Reflections on Self-Delusion The prescient, page-turning account of a journey in Silicon Valley: a defining memoir of our digital age In her mid-twenties, at the height of tech industry idealism, Anna Wiener—stuck, broke, and looking for meaning in her work, like any good millennial--left a job in book publishing for the promise of the new digital economy. She moved from New York to San Francisco, where she landed at a big-data startup in the heart of the Silicon Valley bubble: a world of surreal extravagance, dubious success, and fresh-faced entrepreneurs hell-bent on domination, glory, and, of course, progress. Anna arrived amidst a massive cultural shift, as the tech industry rapidly transformed into a locus of wealth and power rivaling Wall Street. But amid the company ski vacations and in-office speakeasies, boyish camaraderie and ride-or-die corporate fealty, a new Silicon Valley began to emerge: one in far over its head, one that enriched itself at the expense of the idyllic future it claimed to be building. Part coming-age-story, part portrait of an already-bygone era, Anna Wiener’s memoir is a rare first-person glimpse into high-flying, reckless startup culture at a time of unchecked ambition, unregulated surveillance, wild fortune, and accelerating political power. With wit, candor, and heart, Anna deftly charts the tech industry’s shift from self-appointed world savior to democracy-endangering liability, alongside a personal narrative of aspiration, ambivalence, and disillusionment. Unsparing and incisive, Uncanny Valley is a cautionary tale, and a revelatory interrogation of a world reckoning with consequences its unwitting designers are only beginning to understand.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780374719760",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0374719764",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780374719760",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ",
     "pageCount": 288,
     "printType": "BOOK",
     "publishedDate": "2020-01-14",
+    "thumbnail": "https://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Uncanny Valley",
   },
   {
@@ -98,124 +59,72 @@ exports[`addBook works 1`] = `
       "Kimberly Drew",
       "Jenna Wortham",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ",
     "categories": [
       "Social Science",
     ],
     "dateFinished": "2021-01-10",
     "description": "NEW YORK TIMES EDITORS’ CHOICE • An archive of collective memory and exuberant testimony A luminous map to navigate an opaque and disorienting present An infinite geography of possible futures What does it mean to be Black and alive right now? Kimberly Drew and Jenna Wortham have brought together this collection of work—images, photos, essays, memes, dialogues, recipes, tweets, poetry, and more—to tell the story of the radical, imaginative, provocative, and gorgeous world that Black creators are bringing forth today. The book presents a succession of startling and beautiful pieces that generate an entrancing rhythm: Readers will go from conversations with activists and academics to memes and Instagram posts, from powerful essays to dazzling paintings and insightful infographics. In answering the question of what it means to be Black and alive, Black Futures opens a prismatic vision of possibility for every reader.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780399181146",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0399181148",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780399181146",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ",
     "pageCount": 544,
     "printType": "BOOK",
     "publishedDate": "2020-12-01",
+    "thumbnail": "https://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Black Futures",
   },
   {
     "authors": [
       "Silvia Moreno-Garcia",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2021-09-26",
     "description": "NEW YORK TIMES BESTSELLER • “It’s Lovecraft meets the Brontës in Latin America, and after a slow-burn start Mexican Gothic gets seriously weird.”—The Guardian IN DEVELOPMENT AS A HULU ORIGINAL LIMITED SERIES PRODUCED BY KELLY RIPA AND MARK CONSUELOS • FINALIST FOR THE LOCUS AWARD • NOMINATED FOR THE BRAM STOKER AWARD • NAMED ONE OF THE BEST BOOKS OF THE YEAR BY The New Yorker • Vanity Fair • NPR • The Washington Post • Tordotcom • Marie Claire • Vox • Mashable • Men’s Health • Library Journal • Book Riot • LibraryReads An isolated mansion. A chillingly charismatic aristocrat. And a brave socialite drawn to expose their treacherous secrets. . . . From the author of Gods of Jade and Shadow comes “a terrifying twist on classic gothic horror” (Kirkus Reviews) set in glamorous 1950s Mexico. After receiving a frantic letter from her newly-wed cousin begging for someone to save her from a mysterious doom, Noemí Taboada heads to High Place, a distant house in the Mexican countryside. She’s not sure what she will find—her cousin’s husband, a handsome Englishman, is a stranger, and Noemí knows little about the region. Noemí is also an unlikely rescuer: She’s a glamorous debutante, and her chic gowns and perfect red lipstick are more suited for cocktail parties than amateur sleuthing. But she’s also tough and smart, with an indomitable will, and she is not afraid: Not of her cousin’s new husband, who is both menacing and alluring; not of his father, the ancient patriarch who seems to be fascinated by Noemí; and not even of the house itself, which begins to invade Noemi’s dreams with visions of blood and doom. Her only ally in this inhospitable abode is the family’s youngest son. Shy and gentle, he seems to want to help Noemí, but might also be hiding dark knowledge of his family’s past. For there are many secrets behind the walls of High Place. The family’s once colossal wealth and faded mining empire kept them from prying eyes, but as Noemí digs deeper she unearths stories of violence and madness. And Noemí, mesmerized by the terrifying yet seductive world of High Place, may soon find it impossible to ever leave this enigmatic house behind. “It’s as if a supernatural power compels us to turn the pages of the gripping Mexican Gothic.”—The Washington Post “Mexican Gothic is the perfect summer horror read, and marks Moreno-Garcia with her hypnotic and engaging prose as one of the genre’s most exciting talents.”—Nerdist “A period thriller as rich in suspense as it is in lush ’50s atmosphere.”—Entertainment Weekly",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780525620792",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0525620796",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780525620792",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
     "pageCount": 320,
     "printType": "BOOK",
     "publishedDate": "2020-06-30",
+    "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Mexican Gothic",
   },
   {
     "authors": [
       "bell hooks",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ",
     "categories": [
       "Social Science",
     ],
     "dateFinished": "2022-01-13",
     "description": "A classic work of feminist scholarship, Ain't I a Woman has become a must-read for all those interested in the nature of black womanhood. Examining the impact of sexism on black women during slavery, the devaluation of black womanhood, black male sexism, racism among feminists, and the black woman's involvement with feminism, hooks attempts to move us beyond racist and sexist assumptions. The result is nothing short of groundbreaking, giving this book a critical place on every feminist scholar's bookshelf.",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9781317588610",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "1317588614",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9781317588610",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ",
     "pageCount": 206,
     "printType": "BOOK",
     "publishedDate": "2014-12-17",
+    "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Ain't I a Woman",
   },
   {
     "authors": [
       "Kali Fajardo-Anstine",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2022-09-07",
     "description": "NATIONAL BESTSELLER • A dazzling epic of betrayal, love, and fate that spans five generations of an Indigenous Chicano family in the American West, from the author of the National Book Award finalist Sabrina & Corina A Phenomenal Book Club Pick • “Sometimes you just step into a book and let it wash over you, like you’re swimming under a big, sparkling night sky.”—Celeste Ng, author of Little Fires Everywhere and Everything I Never Told You ONE OF THE MOST ANTICIPATED BOOKS OF 2022—The Millions, Electric Lit, Lit Hub, Book Riot There is one every generation, a seer who keeps the stories. Luz “Little Light” Lopez, a tea leaf reader and laundress, is left to fend for herself after her older brother, Diego, a snake charmer and factory worker, is run out of town by a violent white mob. As Luz navigates 1930s Denver, she begins to have visions that transport her to her Indigenous homeland in the nearby Lost Territory. Luz recollects her ancestors’ origins, how her family flourished, and how they were threatened. She bears witness to the sinister forces that have devastated her people and their homelands for generations. In the end, it is up to Luz to save her family stories from disappearing into oblivion. Written in Kali Fajardo-Anstine’s singular voice, the wildly entertaining and complex lives of the Lopez family fill the pages of this multigenerational western saga. Woman of Light is a transfixing novel about survival, family secrets, and love—filled with an unforgettable cast of characters, all of whom are just as special, memorable, and complicated as our beloved heroine, Luz.",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780525511342",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0525511342",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780525511342",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ",
     "pageCount": 336,
     "printType": "BOOK",
     "publishedDate": "2022-06-07",
+    "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Woman of Light",
   },
 ]
@@ -227,32 +136,19 @@ exports[`addBook works, empty file 1`] = `
     "authors": [
       "Yaa Gyasi",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2020-09-12",
     "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "0525658181",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780525658184",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "0525658181",
     "language": "en",
+    "link": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "notes": "Brilliant!",
     "pageCount": 288,
     "printType": "BOOK",
     "publishedDate": "2020",
+    "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "title": "Transcendent Kingdom",
   },
 ]
@@ -264,53 +160,29 @@ exports[`addBook works, no images 1`] = `
     "authors": [
       "Raven Leilani",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
     "dateFinished": "2020-09-06",
     "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "0385696000",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780385696005",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "9780385696005",
     "language": "en",
+    "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
     "pageCount": 240,
     "printType": "BOOK",
     "publishedDate": "2020-08-04",
+    "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "title": "Luster",
   },
   {
     "authors": [
       "Yaa Gyasi",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2020-09-12",
     "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
-    "imageLinks": {},
-    "industryIdentifiers": [
-      {
-        "identifier": "0525658181",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780525658184",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "0525658181",
     "language": "en",
+    "link": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "notes": "Amazing!",
     "pageCount": 288,
     "printType": "BOOK",
@@ -321,31 +193,18 @@ exports[`addBook works, no images 1`] = `
     "authors": [
       "Anna Wiener",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ",
     "categories": [
       "Biography & Autobiography",
     ],
     "dateFinished": "2020-11-22",
     "description": "One of Vogue''s 22 Books to Read This Winter "A definitive document of a world in transition: I won''t be alone in returning to Uncanny Valley for clarity and consolation for many years to come." —Jia Tolentino, author of Trick Mirror: Reflections on Self-Delusion The prescient, page-turning account of a journey in Silicon Valley: a defining memoir of our digital age In her mid-twenties, at the height of tech industry idealism, Anna Wiener—stuck, broke, and looking for meaning in her work, like any good millennial--left a job in book publishing for the promise of the new digital economy. She moved from New York to San Francisco, where she landed at a big-data startup in the heart of the Silicon Valley bubble: a world of surreal extravagance, dubious success, and fresh-faced entrepreneurs hell-bent on domination, glory, and, of course, progress. Anna arrived amidst a massive cultural shift, as the tech industry rapidly transformed into a locus of wealth and power rivaling Wall Street. But amid the company ski vacations and in-office speakeasies, boyish camaraderie and ride-or-die corporate fealty, a new Silicon Valley began to emerge: one in far over its head, one that enriched itself at the expense of the idyllic future it claimed to be building. Part coming-age-story, part portrait of an already-bygone era, Anna Wiener’s memoir is a rare first-person glimpse into high-flying, reckless startup culture at a time of unchecked ambition, unregulated surveillance, wild fortune, and accelerating political power. With wit, candor, and heart, Anna deftly charts the tech industry’s shift from self-appointed world savior to democracy-endangering liability, alongside a personal narrative of aspiration, ambivalence, and disillusionment. Unsparing and incisive, Uncanny Valley is a cautionary tale, and a revelatory interrogation of a world reckoning with consequences its unwitting designers are only beginning to understand.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780374719760",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0374719764",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780374719760",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ",
     "pageCount": 288,
     "printType": "BOOK",
     "publishedDate": "2020-01-14",
+    "thumbnail": "https://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Uncanny Valley",
   },
   {
@@ -353,124 +212,72 @@ exports[`addBook works, no images 1`] = `
       "Kimberly Drew",
       "Jenna Wortham",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ",
     "categories": [
       "Social Science",
     ],
     "dateFinished": "2021-01-10",
     "description": "NEW YORK TIMES EDITORS’ CHOICE • An archive of collective memory and exuberant testimony A luminous map to navigate an opaque and disorienting present An infinite geography of possible futures What does it mean to be Black and alive right now? Kimberly Drew and Jenna Wortham have brought together this collection of work—images, photos, essays, memes, dialogues, recipes, tweets, poetry, and more—to tell the story of the radical, imaginative, provocative, and gorgeous world that Black creators are bringing forth today. The book presents a succession of startling and beautiful pieces that generate an entrancing rhythm: Readers will go from conversations with activists and academics to memes and Instagram posts, from powerful essays to dazzling paintings and insightful infographics. In answering the question of what it means to be Black and alive, Black Futures opens a prismatic vision of possibility for every reader.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780399181146",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0399181148",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780399181146",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ",
     "pageCount": 544,
     "printType": "BOOK",
     "publishedDate": "2020-12-01",
+    "thumbnail": "https://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Black Futures",
   },
   {
     "authors": [
       "Silvia Moreno-Garcia",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2021-09-26",
     "description": "NEW YORK TIMES BESTSELLER • “It’s Lovecraft meets the Brontës in Latin America, and after a slow-burn start Mexican Gothic gets seriously weird.”—The Guardian IN DEVELOPMENT AS A HULU ORIGINAL LIMITED SERIES PRODUCED BY KELLY RIPA AND MARK CONSUELOS • FINALIST FOR THE LOCUS AWARD • NOMINATED FOR THE BRAM STOKER AWARD • NAMED ONE OF THE BEST BOOKS OF THE YEAR BY The New Yorker • Vanity Fair • NPR • The Washington Post • Tordotcom • Marie Claire • Vox • Mashable • Men’s Health • Library Journal • Book Riot • LibraryReads An isolated mansion. A chillingly charismatic aristocrat. And a brave socialite drawn to expose their treacherous secrets. . . . From the author of Gods of Jade and Shadow comes “a terrifying twist on classic gothic horror” (Kirkus Reviews) set in glamorous 1950s Mexico. After receiving a frantic letter from her newly-wed cousin begging for someone to save her from a mysterious doom, Noemí Taboada heads to High Place, a distant house in the Mexican countryside. She’s not sure what she will find—her cousin’s husband, a handsome Englishman, is a stranger, and Noemí knows little about the region. Noemí is also an unlikely rescuer: She’s a glamorous debutante, and her chic gowns and perfect red lipstick are more suited for cocktail parties than amateur sleuthing. But she’s also tough and smart, with an indomitable will, and she is not afraid: Not of her cousin’s new husband, who is both menacing and alluring; not of his father, the ancient patriarch who seems to be fascinated by Noemí; and not even of the house itself, which begins to invade Noemi’s dreams with visions of blood and doom. Her only ally in this inhospitable abode is the family’s youngest son. Shy and gentle, he seems to want to help Noemí, but might also be hiding dark knowledge of his family’s past. For there are many secrets behind the walls of High Place. The family’s once colossal wealth and faded mining empire kept them from prying eyes, but as Noemí digs deeper she unearths stories of violence and madness. And Noemí, mesmerized by the terrifying yet seductive world of High Place, may soon find it impossible to ever leave this enigmatic house behind. “It’s as if a supernatural power compels us to turn the pages of the gripping Mexican Gothic.”—The Washington Post “Mexican Gothic is the perfect summer horror read, and marks Moreno-Garcia with her hypnotic and engaging prose as one of the genre’s most exciting talents.”—Nerdist “A period thriller as rich in suspense as it is in lush ’50s atmosphere.”—Entertainment Weekly",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780525620792",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0525620796",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780525620792",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
     "pageCount": 320,
     "printType": "BOOK",
     "publishedDate": "2020-06-30",
+    "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Mexican Gothic",
   },
   {
     "authors": [
       "bell hooks",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ",
     "categories": [
       "Social Science",
     ],
     "dateFinished": "2022-01-13",
     "description": "A classic work of feminist scholarship, Ain't I a Woman has become a must-read for all those interested in the nature of black womanhood. Examining the impact of sexism on black women during slavery, the devaluation of black womanhood, black male sexism, racism among feminists, and the black woman's involvement with feminism, hooks attempts to move us beyond racist and sexist assumptions. The result is nothing short of groundbreaking, giving this book a critical place on every feminist scholar's bookshelf.",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9781317588610",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "1317588614",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9781317588610",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ",
     "pageCount": 206,
     "printType": "BOOK",
     "publishedDate": "2014-12-17",
+    "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Ain't I a Woman",
   },
   {
     "authors": [
       "Kali Fajardo-Anstine",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2022-09-07",
     "description": "NATIONAL BESTSELLER • A dazzling epic of betrayal, love, and fate that spans five generations of an Indigenous Chicano family in the American West, from the author of the National Book Award finalist Sabrina & Corina A Phenomenal Book Club Pick • “Sometimes you just step into a book and let it wash over you, like you’re swimming under a big, sparkling night sky.”—Celeste Ng, author of Little Fires Everywhere and Everything I Never Told You ONE OF THE MOST ANTICIPATED BOOKS OF 2022—The Millions, Electric Lit, Lit Hub, Book Riot There is one every generation, a seer who keeps the stories. Luz “Little Light” Lopez, a tea leaf reader and laundress, is left to fend for herself after her older brother, Diego, a snake charmer and factory worker, is run out of town by a violent white mob. As Luz navigates 1930s Denver, she begins to have visions that transport her to her Indigenous homeland in the nearby Lost Territory. Luz recollects her ancestors’ origins, how her family flourished, and how they were threatened. She bears witness to the sinister forces that have devastated her people and their homelands for generations. In the end, it is up to Luz to save her family stories from disappearing into oblivion. Written in Kali Fajardo-Anstine’s singular voice, the wildly entertaining and complex lives of the Lopez family fill the pages of this multigenerational western saga. Woman of Light is a transfixing novel about survival, family secrets, and love—filled with an unforgettable cast of characters, all of whom are just as special, memorable, and complicated as our beloved heroine, Luz.",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780525511342",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0525511342",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780525511342",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ",
     "pageCount": 336,
     "printType": "BOOK",
     "publishedDate": "2022-06-07",
+    "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Woman of Light",
   },
 ]

--- a/src/__tests__/__snapshots__/clean-book.test.ts.snap
+++ b/src/__tests__/__snapshots__/clean-book.test.ts.snap
@@ -5,32 +5,19 @@ exports[`cleanBook cleanBook 1`] = `
   "authors": [
     "Yaa Gyasi",
   ],
-  "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
   "categories": [
     "Fiction",
   ],
   "dateFinished": "2020-09-12",
   "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
-  "imageLinks": {
-    "smallThumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-    "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-  },
-  "industryIdentifiers": [
-    {
-      "identifier": "0525658181",
-      "type": "ISBN_10",
-    },
-    {
-      "identifier": "9780525658184",
-      "type": "ISBN_13",
-    },
-  ],
   "isbn": "0525658181",
   "language": "en",
+  "link": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
   "notes": "I loved it!",
   "pageCount": 288,
   "printType": "BOOK",
   "publishedDate": "2020",
+  "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
   "title": "Transcendent Kingdom",
 }
 `;
@@ -40,32 +27,19 @@ exports[`cleanBook cleanBook, no date 1`] = `
   "authors": [
     "Yaa Gyasi",
   ],
-  "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
   "categories": [
     "Fiction",
   ],
   "dateFinished": "2020-01-01",
   "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
-  "imageLinks": {
-    "smallThumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-    "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-  },
-  "industryIdentifiers": [
-    {
-      "identifier": "0525658181",
-      "type": "ISBN_10",
-    },
-    {
-      "identifier": "9780525658184",
-      "type": "ISBN_13",
-    },
-  ],
   "isbn": "0525658181",
   "language": "en",
+  "link": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
   "notes": "I loved it!",
   "pageCount": 288,
   "printType": "BOOK",
   "publishedDate": "2020",
+  "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
   "title": "Transcendent Kingdom",
 }
 `;

--- a/src/__tests__/__snapshots__/get-book.test.ts.snap
+++ b/src/__tests__/__snapshots__/get-book.test.ts.snap
@@ -6,90 +6,51 @@ exports[`getBook works 1`] = `
     "authors": [
       "Raven Leilani",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
     "dateFinished": "2020-09-06",
     "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "0385696000",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780385696005",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "9780385696005",
     "language": "en",
+    "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
     "pageCount": 240,
     "printType": "BOOK",
     "publishedDate": "2020-08-04",
+    "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "title": "Luster",
   },
   {
     "authors": [
       "Yaa Gyasi",
     ],
-    "canonicalVolumeLink": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2020-09-12",
     "description": "A novel about faith, science, religion, and family that tells the deeply moving portrait of a family of Ghanaian immigrants ravaged by depression and addiction and grief, narrated by a fifth year candidate in neuroscience at Stanford school of medicine studying the neural circuits of reward seeking behavior in mice…",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "0525658181",
-        "type": "ISBN_10",
-      },
-      {
-        "identifier": "9780525658184",
-        "type": "ISBN_13",
-      },
-    ],
     "isbn": "9780525658184",
     "language": "en",
+    "link": "https://books.google.com/books/about/Transcendent_Kingdom.html?hl=&id=ty19yQEACAAJ",
     "pageCount": 288,
     "printType": "BOOK",
     "publishedDate": "2020",
+    "thumbnail": "https://books.google.com/books/content?id=ty19yQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
     "title": "Transcendent Kingdom",
   },
   {
     "authors": [
       "Anna Wiener",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ",
     "categories": [
       "Biography & Autobiography",
     ],
     "dateFinished": "2020-11-22",
     "description": "One of Vogue''s 22 Books to Read This Winter "A definitive document of a world in transition: I won''t be alone in returning to Uncanny Valley for clarity and consolation for many years to come." —Jia Tolentino, author of Trick Mirror: Reflections on Self-Delusion The prescient, page-turning account of a journey in Silicon Valley: a defining memoir of our digital age In her mid-twenties, at the height of tech industry idealism, Anna Wiener—stuck, broke, and looking for meaning in her work, like any good millennial--left a job in book publishing for the promise of the new digital economy. She moved from New York to San Francisco, where she landed at a big-data startup in the heart of the Silicon Valley bubble: a world of surreal extravagance, dubious success, and fresh-faced entrepreneurs hell-bent on domination, glory, and, of course, progress. Anna arrived amidst a massive cultural shift, as the tech industry rapidly transformed into a locus of wealth and power rivaling Wall Street. But amid the company ski vacations and in-office speakeasies, boyish camaraderie and ride-or-die corporate fealty, a new Silicon Valley began to emerge: one in far over its head, one that enriched itself at the expense of the idyllic future it claimed to be building. Part coming-age-story, part portrait of an already-bygone era, Anna Wiener’s memoir is a rare first-person glimpse into high-flying, reckless startup culture at a time of unchecked ambition, unregulated surveillance, wild fortune, and accelerating political power. With wit, candor, and heart, Anna deftly charts the tech industry’s shift from self-appointed world savior to democracy-endangering liability, alongside a personal narrative of aspiration, ambivalence, and disillusionment. Unsparing and incisive, Uncanny Valley is a cautionary tale, and a revelatory interrogation of a world reckoning with consequences its unwitting designers are only beginning to understand.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780374719760",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0374719764",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780374719760",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=5fqTDwAAQBAJ",
     "pageCount": 288,
     "printType": "BOOK",
     "publishedDate": "2020-01-14",
+    "thumbnail": "https://books.google.com/books/content?id=5fqTDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Uncanny Valley",
   },
   {
@@ -97,124 +58,72 @@ exports[`getBook works 1`] = `
       "Kimberly Drew",
       "Jenna Wortham",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ",
     "categories": [
       "Social Science",
     ],
     "dateFinished": "2021-01-10",
     "description": "NEW YORK TIMES EDITORS’ CHOICE • An archive of collective memory and exuberant testimony A luminous map to navigate an opaque and disorienting present An infinite geography of possible futures What does it mean to be Black and alive right now? Kimberly Drew and Jenna Wortham have brought together this collection of work—images, photos, essays, memes, dialogues, recipes, tweets, poetry, and more—to tell the story of the radical, imaginative, provocative, and gorgeous world that Black creators are bringing forth today. The book presents a succession of startling and beautiful pieces that generate an entrancing rhythm: Readers will go from conversations with activists and academics to memes and Instagram posts, from powerful essays to dazzling paintings and insightful infographics. In answering the question of what it means to be Black and alive, Black Futures opens a prismatic vision of possibility for every reader.",
-    "imageLinks": {
-      "smallThumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "http://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780399181146",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0399181148",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780399181146",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=pUGGDwAAQBAJ",
     "pageCount": 544,
     "printType": "BOOK",
     "publishedDate": "2020-12-01",
+    "thumbnail": "https://books.google.com/books/content?id=pUGGDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Black Futures",
   },
   {
     "authors": [
       "Silvia Moreno-Garcia",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2021-09-26",
     "description": "NEW YORK TIMES BESTSELLER • “It’s Lovecraft meets the Brontës in Latin America, and after a slow-burn start Mexican Gothic gets seriously weird.”—The Guardian IN DEVELOPMENT AS A HULU ORIGINAL LIMITED SERIES PRODUCED BY KELLY RIPA AND MARK CONSUELOS • FINALIST FOR THE LOCUS AWARD • NOMINATED FOR THE BRAM STOKER AWARD • NAMED ONE OF THE BEST BOOKS OF THE YEAR BY The New Yorker • Vanity Fair • NPR • The Washington Post • Tordotcom • Marie Claire • Vox • Mashable • Men’s Health • Library Journal • Book Riot • LibraryReads An isolated mansion. A chillingly charismatic aristocrat. And a brave socialite drawn to expose their treacherous secrets. . . . From the author of Gods of Jade and Shadow comes “a terrifying twist on classic gothic horror” (Kirkus Reviews) set in glamorous 1950s Mexico. After receiving a frantic letter from her newly-wed cousin begging for someone to save her from a mysterious doom, Noemí Taboada heads to High Place, a distant house in the Mexican countryside. She’s not sure what she will find—her cousin’s husband, a handsome Englishman, is a stranger, and Noemí knows little about the region. Noemí is also an unlikely rescuer: She’s a glamorous debutante, and her chic gowns and perfect red lipstick are more suited for cocktail parties than amateur sleuthing. But she’s also tough and smart, with an indomitable will, and she is not afraid: Not of her cousin’s new husband, who is both menacing and alluring; not of his father, the ancient patriarch who seems to be fascinated by Noemí; and not even of the house itself, which begins to invade Noemi’s dreams with visions of blood and doom. Her only ally in this inhospitable abode is the family’s youngest son. Shy and gentle, he seems to want to help Noemí, but might also be hiding dark knowledge of his family’s past. For there are many secrets behind the walls of High Place. The family’s once colossal wealth and faded mining empire kept them from prying eyes, but as Noemí digs deeper she unearths stories of violence and madness. And Noemí, mesmerized by the terrifying yet seductive world of High Place, may soon find it impossible to ever leave this enigmatic house behind. “It’s as if a supernatural power compels us to turn the pages of the gripping Mexican Gothic.”—The Washington Post “Mexican Gothic is the perfect summer horror read, and marks Moreno-Garcia with her hypnotic and engaging prose as one of the genre’s most exciting talents.”—Nerdist “A period thriller as rich in suspense as it is in lush ’50s atmosphere.”—Entertainment Weekly",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780525620792",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0525620796",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780525620792",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
     "pageCount": 320,
     "printType": "BOOK",
     "publishedDate": "2020-06-30",
+    "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Mexican Gothic",
   },
   {
     "authors": [
       "bell hooks",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ",
     "categories": [
       "Social Science",
     ],
     "dateFinished": "2022-01-13",
     "description": "A classic work of feminist scholarship, Ain't I a Woman has become a must-read for all those interested in the nature of black womanhood. Examining the impact of sexism on black women during slavery, the devaluation of black womanhood, black male sexism, racism among feminists, and the black woman's involvement with feminism, hooks attempts to move us beyond racist and sexist assumptions. The result is nothing short of groundbreaking, giving this book a critical place on every feminist scholar's bookshelf.",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9781317588610",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "1317588614",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9781317588610",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=f2_fBQAAQBAJ",
     "pageCount": 206,
     "printType": "BOOK",
     "publishedDate": "2014-12-17",
+    "thumbnail": "https://books.google.com/books/content?id=f2_fBQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Ain't I a Woman",
   },
   {
     "authors": [
       "Kali Fajardo-Anstine",
     ],
-    "canonicalVolumeLink": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ",
     "categories": [
       "Fiction",
     ],
     "dateFinished": "2022-09-07",
     "description": "NATIONAL BESTSELLER • A dazzling epic of betrayal, love, and fate that spans five generations of an Indigenous Chicano family in the American West, from the author of the National Book Award finalist Sabrina & Corina A Phenomenal Book Club Pick • “Sometimes you just step into a book and let it wash over you, like you’re swimming under a big, sparkling night sky.”—Celeste Ng, author of Little Fires Everywhere and Everything I Never Told You ONE OF THE MOST ANTICIPATED BOOKS OF 2022—The Millions, Electric Lit, Lit Hub, Book Riot There is one every generation, a seer who keeps the stories. Luz “Little Light” Lopez, a tea leaf reader and laundress, is left to fend for herself after her older brother, Diego, a snake charmer and factory worker, is run out of town by a violent white mob. As Luz navigates 1930s Denver, she begins to have visions that transport her to her Indigenous homeland in the nearby Lost Territory. Luz recollects her ancestors’ origins, how her family flourished, and how they were threatened. She bears witness to the sinister forces that have devastated her people and their homelands for generations. In the end, it is up to Luz to save her family stories from disappearing into oblivion. Written in Kali Fajardo-Anstine’s singular voice, the wildly entertaining and complex lives of the Lopez family fill the pages of this multigenerational western saga. Woman of Light is a transfixing novel about survival, family secrets, and love—filled with an unforgettable cast of characters, all of whom are just as special, memorable, and complicated as our beloved heroine, Luz.",
-    "imageLinks": {
-      "smallThumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
-    "industryIdentifiers": [
-      {
-        "identifier": "9780525511342",
-        "type": "ISBN_13",
-      },
-      {
-        "identifier": "0525511342",
-        "type": "ISBN_10",
-      },
-    ],
     "isbn": "9780525511342",
     "language": "en",
+    "link": "https://play.google.com/store/books/details?id=5LhBEAAAQBAJ",
     "pageCount": 336,
     "printType": "BOOK",
     "publishedDate": "2022-06-07",
+    "thumbnail": "https://books.google.com/books/content?id=5LhBEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     "title": "Woman of Light",
   },
 ]

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -109,28 +109,15 @@ describe("index", () => {
             "authors": [
               "Raven Leilani",
             ],
-            "canonicalVolumeLink": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
             "dateFinished": "2022-01-18",
             "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
-            "imageLinks": {
-              "smallThumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
-              "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-            },
-            "industryIdentifiers": [
-              {
-                "identifier": "0385696000",
-                "type": "ISBN_10",
-              },
-              {
-                "identifier": "9780385696005",
-                "type": "ISBN_13",
-              },
-            ],
             "isbn": "9780385696005",
             "language": "en",
+            "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
             "pageCount": 240,
             "printType": "BOOK",
             "publishedDate": "2020-08-04",
+            "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
             "title": "Luster",
           },
         ],

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,24 +11,14 @@ const mockReadFile = JSON.stringify([
     title: "Mexican Gothic",
     authors: ["Silvia Moreno-Garcia"],
     publishedDate: "2020-06-30",
-    description:
-      "NEW YORK TIMES BESTSELLER • “It’s Lovecraft meets the Brontës in Latin America, and after a slow-burn start Mexican Gothic gets seriously weird.”—The Guardian IN DEVELOPMENT AS A HULU ORIGINAL LIMITED SERIES PRODUCED BY KELLY RIPA AND MARK CONSUELOS • FINALIST FOR THE LOCUS AWARD • NOMINATED FOR THE BRAM STOKER AWARD • NAMED ONE OF THE BEST BOOKS OF THE YEAR BY The New Yorker • Vanity Fair • NPR • The Washington Post • Tordotcom • Marie Claire • Vox • Mashable • Men’s Health • Library Journal • Book Riot • LibraryReads An isolated mansion. A chillingly charismatic aristocrat. And a brave socialite drawn to expose their treacherous secrets. . . . From the author of Gods of Jade and Shadow comes “a terrifying twist on classic gothic horror” (Kirkus Reviews) set in glamorous 1950s Mexico. After receiving a frantic letter from her newly-wed cousin begging for someone to save her from a mysterious doom, Noemí Taboada heads to High Place, a distant house in the Mexican countryside. She’s not sure what she will find—her cousin’s husband, a handsome Englishman, is a stranger, and Noemí knows little about the region. Noemí is also an unlikely rescuer: She’s a glamorous debutante, and her chic gowns and perfect red lipstick are more suited for cocktail parties than amateur sleuthing. But she’s also tough and smart, with an indomitable will, and she is not afraid: Not of her cousin’s new husband, who is both menacing and alluring; not of his father, the ancient patriarch who seems to be fascinated by Noemí; and not even of the house itself, which begins to invade Noemi’s dreams with visions of blood and doom. Her only ally in this inhospitable abode is the family’s youngest son. Shy and gentle, he seems to want to help Noemí, but might also be hiding dark knowledge of his family’s past. For there are many secrets behind the walls of High Place. The family’s once colossal wealth and faded mining empire kept them from prying eyes, but as Noemí digs deeper she unearths stories of violence and madness. And Noemí, mesmerized by the terrifying yet seductive world of High Place, may soon find it impossible to ever leave this enigmatic house behind. “It’s as if a supernatural power compels us to turn the pages of the gripping Mexican Gothic.”—The Washington Post “Mexican Gothic is the perfect summer horror read, and marks Moreno-Garcia with her hypnotic and engaging prose as one of the genre’s most exciting talents.”—Nerdist “A period thriller as rich in suspense as it is in lush ’50s atmosphere.”—Entertainment Weekly",
-    industryIdentifiers: [
-      { type: "ISBN_13", identifier: "9780525620792" },
-      { type: "ISBN_10", identifier: "0525620796" },
-    ],
+    description: "NEW YORK TIMES BESTSELLER",
     pageCount: 320,
     printType: "BOOK",
     categories: ["Fiction"],
-    imageLinks: {
-      smallThumbnail:
-        "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-      thumbnail:
-        "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-    },
+    thumbnail:
+      "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
     language: "en",
-    canonicalVolumeLink:
-      "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
+    link: "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
   },
 ]);
 
@@ -78,31 +68,18 @@ describe("index", () => {
             "authors": [
               "Silvia Moreno-Garcia",
             ],
-            "canonicalVolumeLink": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
             "categories": [
               "Fiction",
             ],
             "dateFinished": "2021-09-26",
-            "description": "NEW YORK TIMES BESTSELLER • “It’s Lovecraft meets the Brontës in Latin America, and after a slow-burn start Mexican Gothic gets seriously weird.”—The Guardian IN DEVELOPMENT AS A HULU ORIGINAL LIMITED SERIES PRODUCED BY KELLY RIPA AND MARK CONSUELOS • FINALIST FOR THE LOCUS AWARD • NOMINATED FOR THE BRAM STOKER AWARD • NAMED ONE OF THE BEST BOOKS OF THE YEAR BY The New Yorker • Vanity Fair • NPR • The Washington Post • Tordotcom • Marie Claire • Vox • Mashable • Men’s Health • Library Journal • Book Riot • LibraryReads An isolated mansion. A chillingly charismatic aristocrat. And a brave socialite drawn to expose their treacherous secrets. . . . From the author of Gods of Jade and Shadow comes “a terrifying twist on classic gothic horror” (Kirkus Reviews) set in glamorous 1950s Mexico. After receiving a frantic letter from her newly-wed cousin begging for someone to save her from a mysterious doom, Noemí Taboada heads to High Place, a distant house in the Mexican countryside. She’s not sure what she will find—her cousin’s husband, a handsome Englishman, is a stranger, and Noemí knows little about the region. Noemí is also an unlikely rescuer: She’s a glamorous debutante, and her chic gowns and perfect red lipstick are more suited for cocktail parties than amateur sleuthing. But she’s also tough and smart, with an indomitable will, and she is not afraid: Not of her cousin’s new husband, who is both menacing and alluring; not of his father, the ancient patriarch who seems to be fascinated by Noemí; and not even of the house itself, which begins to invade Noemi’s dreams with visions of blood and doom. Her only ally in this inhospitable abode is the family’s youngest son. Shy and gentle, he seems to want to help Noemí, but might also be hiding dark knowledge of his family’s past. For there are many secrets behind the walls of High Place. The family’s once colossal wealth and faded mining empire kept them from prying eyes, but as Noemí digs deeper she unearths stories of violence and madness. And Noemí, mesmerized by the terrifying yet seductive world of High Place, may soon find it impossible to ever leave this enigmatic house behind. “It’s as if a supernatural power compels us to turn the pages of the gripping Mexican Gothic.”—The Washington Post “Mexican Gothic is the perfect summer horror read, and marks Moreno-Garcia with her hypnotic and engaging prose as one of the genre’s most exciting talents.”—Nerdist “A period thriller as rich in suspense as it is in lush ’50s atmosphere.”—Entertainment Weekly",
-            "imageLinks": {
-              "smallThumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
-              "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-            },
-            "industryIdentifiers": [
-              {
-                "identifier": "9780525620792",
-                "type": "ISBN_13",
-              },
-              {
-                "identifier": "0525620796",
-                "type": "ISBN_10",
-              },
-            ],
+            "description": "NEW YORK TIMES BESTSELLER",
             "isbn": "9780525620792",
             "language": "en",
+            "link": "https://play.google.com/store/books/details?id=ksKyDwAAQBAJ",
             "pageCount": 320,
             "printType": "BOOK",
             "publishedDate": "2020-06-30",
+            "thumbnail": "https://books.google.com/books/content?id=ksKyDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
             "title": "Mexican Gothic",
           },
           {

--- a/src/add-book.ts
+++ b/src/add-book.ts
@@ -14,9 +14,9 @@ export default async function addBook(
   // clean up book data
   const newBook: CleanBook = cleanBook(options, book);
   // export book thumbnail to download later
-  if (newBook.imageLinks && newBook.imageLinks.thumbnail) {
+  if (newBook.thumbnail) {
     exportVariable("BookThumbOutput", `book-${newBook.isbn}.png`);
-    exportVariable("BookThumb", newBook.imageLinks.thumbnail);
+    exportVariable("BookThumb", newBook.thumbnail);
   }
   // append new book
   readListJson.push(newBook);

--- a/src/clean-book.ts
+++ b/src/clean-book.ts
@@ -7,16 +7,12 @@ export type CleanBook = {
   authors?: string[];
   publishedDate?: string;
   description?: string;
-  industryIdentifiers?: { type?: string; indentifier?: string }[];
   categories?: string[];
   pageCount?: number;
   printType?: string;
-  imageLinks?: {
-    smallThumbnail?: string;
-    thumbnail?: string;
-  };
+  thumbnail?: string;
   language?: string;
-  canonicalVolumeLink?: string;
+  link?: string;
   isbn: string;
   notes?: string;
 };
@@ -35,28 +31,16 @@ export default function cleanBook(options: BookOptions, book: Book): CleanBook {
     ...("description" in book && {
       description: removeWrappedQuotes(book.description),
     }),
-    ...("industryIdentifiers" in book && {
-      industryIdentifiers: book.industryIdentifiers,
-    }),
     ...("pageCount" in book && { pageCount: book.pageCount }),
     ...("printType" in book && { printType: book.printType }),
     ...("categories" in book && { categories: book.categories }),
-    ...("imageLinks" in book && {
-      imageLinks: {
-        ...("smallThumbnail" in book.imageLinks && {
-          smallThumbnail: book.imageLinks.smallThumbnail.replace(
-            "http:",
-            "https:"
-          ),
-        }),
-        ...("thumbnail" in book.imageLinks && {
-          thumbnail: book.imageLinks.thumbnail.replace("http:", "https:"),
-        }),
-      },
-    }),
+    ...("imageLinks" in book &&
+      "thumbnail" in book.imageLinks && {
+        thumbnail: book.imageLinks.thumbnail.replace("http:", "https:"),
+      }),
     ...("language" in book && { language: book.language }),
     ...("canonicalVolumeLink" in book && {
-      canonicalVolumeLink: book.canonicalVolumeLink,
+      link: book.canonicalVolumeLink,
     }),
   };
 }


### PR DESCRIPTION
Reducing some metadata to remove redundancy and (unlikely) used items:

- ✂️ Remove `industryIdentifiers`, this is covered by `isbn`
- ✂️ Remove `imageLinks.smallThumbnail`
- 🖊 Rename `imageLinks.smallThumbnail` to `thumbnail`
- 🖊 Rename `canonicalVolumeLink` to `link`