### PR TITLE
fix: Allow updating of book dates

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14321,8 +14321,8 @@ function getBook(options, fileName) {
     });
 }
 
-;// CONCATENATED MODULE: ./src/finished-book.ts
-var finished_book_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+;// CONCATENATED MODULE: ./src/checkout-book.ts
+var checkout_book_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -14333,8 +14333,8 @@ var finished_book_awaiter = (undefined && undefined.__awaiter) || function (this
 };
 
 
-function finishedBook({ fileName, bookIsbn, dates, notes, bookStatus, }) {
-    return finished_book_awaiter(this, void 0, void 0, function* () {
+function checkOutBook({ fileName, bookIsbn, dates, notes, bookStatus, }) {
+    return checkout_book_awaiter(this, void 0, void 0, function* () {
         const currentBooks = yield returnReadFile(fileName);
         if (currentBooks === undefined || currentBooks.length === 0)
             return false;
@@ -14350,14 +14350,11 @@ function finishedBook({ fileName, bookIsbn, dates, notes, bookStatus, }) {
     });
 }
 function updateBook({ currentBooks, bookIsbn, dates, notes, bookStatus, }) {
-    return finished_book_awaiter(this, void 0, void 0, function* () {
+    return checkout_book_awaiter(this, void 0, void 0, function* () {
         return currentBooks.reduce((arr, book) => {
             if (book.isbn === bookIsbn) {
                 (0,core.exportVariable)("BookTitle", book.title);
-                book.dateFinished = dates.dateFinished;
-                book.status = bookStatus;
-                if (notes || book.notes)
-                    book.notes = notes || book.notes;
+                book = Object.assign(Object.assign(Object.assign(Object.assign({}, book), dates), { status: bookStatus }), (notes || book.notes) && { notes: notes || book.notes });
             }
             arr.push(book);
             return arr;
@@ -14417,7 +14414,7 @@ function read() {
             };
             (0,core.exportVariable)("BookStatus", bookStatus);
             // Check if book already exists in library
-            const bookExists = yield finishedBook({
+            const bookExists = yield checkOutBook({
                 fileName,
                 bookIsbn,
                 dates,

--- a/dist/index.js
+++ b/dist/index.js
@@ -14354,7 +14354,7 @@ function updateBook({ currentBooks, bookIsbn, dates, notes, bookStatus, }) {
         return currentBooks.reduce((arr, book) => {
             if (book.isbn === bookIsbn) {
                 (0,core.exportVariable)("BookTitle", book.title);
-                book = Object.assign(Object.assign(Object.assign({}, book), { dateAdded: book.dateAdded || dates.dateAdded, dateStarted: book.dateStarted || dates.dateStarted, dateFinished: book.dateFinished || dates.dateFinished, status: bookStatus }), (notes) && { notes });
+                book = Object.assign(Object.assign(Object.assign({}, book), { dateAdded: book.dateAdded || dates.dateAdded, dateStarted: book.dateStarted || dates.dateStarted, dateFinished: book.dateFinished || dates.dateFinished, status: bookStatus }), (notes && { notes }));
             }
             arr.push(book);
             return arr;

--- a/dist/index.js
+++ b/dist/index.js
@@ -14354,7 +14354,7 @@ function updateBook({ currentBooks, bookIsbn, dates, notes, bookStatus, }) {
         return currentBooks.reduce((arr, book) => {
             if (book.isbn === bookIsbn) {
                 (0,core.exportVariable)("BookTitle", book.title);
-                book = Object.assign(Object.assign(Object.assign(Object.assign({}, book), dates), { status: bookStatus }), (notes || book.notes) && { notes: notes || book.notes });
+                book = Object.assign(Object.assign(Object.assign({}, book), { dateAdded: book.dateAdded || dates.dateAdded, dateStarted: book.dateStarted || dates.dateStarted, dateFinished: book.dateFinished || dates.dateFinished, status: bookStatus }), (notes) && { notes });
             }
             arr.push(book);
             return arr;

--- a/src/__tests__/checkout-book.ts
+++ b/src/__tests__/checkout-book.ts
@@ -44,7 +44,7 @@ describe("checkOutBook", () => {
                 {
                   "dateAdded": undefined,
                   "dateFinished": "2022-02-02",
-                  "dateStarted": undefined,
+                  "dateStarted": "2021-09-26",
                   "isbn": "9780525620792",
                   "notes": "Recommended by my sister.",
                   "status": "finished",
@@ -80,7 +80,7 @@ describe("checkOutBook", () => {
                 {
                   "dateAdded": undefined,
                   "dateFinished": "2022-02-02",
-                  "dateStarted": undefined,
+                  "dateStarted": "2021-09-26",
                   "isbn": "9780525620792",
                   "notes": "Great read",
                   "status": "finished",

--- a/src/__tests__/checkout-book.ts
+++ b/src/__tests__/checkout-book.ts
@@ -1,4 +1,4 @@
-import { finishedBook } from "../finished-book";
+import { checkOutBook } from "../checkout-book";
 import { promises } from "fs";
 
 jest.mock("@actions/core");
@@ -18,11 +18,11 @@ const mockReadFile = JSON.stringify([
   },
 ]);
 
-describe("finishedBook", () => {
+describe("checkOutBook", () => {
   it("works", async () => {
     jest.spyOn(promises, "readFile").mockResolvedValue(mockReadFile);
     return expect(
-      finishedBook({
+      checkOutBook({
         fileName: "my-library.yml",
         bookIsbn: "9780525620792",
         dates: {
@@ -30,6 +30,7 @@ describe("finishedBook", () => {
           dateStarted: undefined,
           dateFinished: "2022-02-02",
         },
+
         bookStatus: "finished",
       })
     ).resolves.toMatchInlineSnapshot(`
@@ -41,8 +42,9 @@ describe("finishedBook", () => {
                   "title": "Uncanny Valley",
                 },
                 {
+                  "dateAdded": undefined,
                   "dateFinished": "2022-02-02",
-                  "dateStarted": "2021-09-26",
+                  "dateStarted": undefined,
                   "isbn": "9780525620792",
                   "notes": "Recommended by my sister.",
                   "status": "finished",
@@ -55,7 +57,7 @@ describe("finishedBook", () => {
   it("works, notes", async () => {
     jest.spyOn(promises, "readFile").mockResolvedValue(mockReadFile);
     return expect(
-      finishedBook({
+      checkOutBook({
         fileName: "my-library.yml",
         bookIsbn: "9780525620792",
         dates: {
@@ -63,6 +65,7 @@ describe("finishedBook", () => {
           dateStarted: undefined,
           dateFinished: "2022-02-02",
         },
+
         notes: "Great read",
         bookStatus: "finished",
       })
@@ -75,8 +78,9 @@ describe("finishedBook", () => {
                   "title": "Uncanny Valley",
                 },
                 {
+                  "dateAdded": undefined,
                   "dateFinished": "2022-02-02",
-                  "dateStarted": "2021-09-26",
+                  "dateStarted": undefined,
                   "isbn": "9780525620792",
                   "notes": "Great read",
                   "status": "finished",
@@ -89,7 +93,7 @@ describe("finishedBook", () => {
   it("does not find book", async () => {
     jest.spyOn(promises, "readFile").mockResolvedValue(mockReadFile);
     return expect(
-      finishedBook({
+      checkOutBook({
         fileName: "my-library.yml",
         bookIsbn: "12345",
         dates: {
@@ -105,7 +109,7 @@ describe("finishedBook", () => {
   it("no library", async () => {
     jest.spyOn(promises, "readFile").mockResolvedValue(`[]`);
     return expect(
-      finishedBook({
+      checkOutBook({
         fileName: "my-library.yml",
         bookIsbn: "12345",
         dates: {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -140,8 +140,9 @@ describe("index", () => {
             "categories": [
               "Fiction",
             ],
+            "dateAdded": undefined,
             "dateFinished": "2021-09-30",
-            "dateStarted": "2021-09-26",
+            "dateStarted": undefined,
             "description": "NEW YORK TIMES BESTSELLER",
             "isbn": "9780525620792",
             "language": "en",
@@ -509,5 +510,205 @@ describe("index", () => {
     expect(setFailedSpy).toHaveBeenCalledWith(
       "Invalid `dateStarted` in payload: 1234"
     );
+  });
+});
+
+describe("workflow", () => {
+  test("want to read", async () => {
+    jest.spyOn(promises, "readFile").mockResolvedValue();
+    jest.useFakeTimers().setSystemTime(new Date("2022-10-01T12:00:00"));
+
+    const exportVariableSpy = jest.spyOn(core, "exportVariable");
+    const setFailedSpy = jest.spyOn(core, "setFailed");
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementationOnce(() => "my-library.json");
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementation((v) => (v === "timeZone" ? "America/New_York" : ""));
+    Object.defineProperty(github, "context", {
+      value: {
+        payload: {
+          inputs: {
+            bookIsbn: "9780385696005",
+          },
+        },
+      },
+    });
+    await read();
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(
+      1,
+      "BookStatus",
+      "want to read"
+    );
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(2, "BookTitle", "Luster");
+
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(
+      3,
+      "BookThumbOutput",
+      "book-9780385696005.png"
+    );
+    expect(setFailedSpy).not.toHaveBeenCalled();
+    expect(returnWriteFile.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        "my-library.json",
+        [
+          {
+            "authors": [
+              "Raven Leilani",
+            ],
+            "dateAdded": "2022-10-01",
+            "dateFinished": undefined,
+            "dateStarted": undefined,
+            "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
+            "isbn": "9780385696005",
+            "language": "en",
+            "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
+            "pageCount": 240,
+            "printType": "BOOK",
+            "publishedDate": "2020-08-04",
+            "status": "want to read",
+            "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+            "title": "Luster",
+          },
+        ],
+      ]
+    `);
+  });
+
+  test("started", async () => {
+    jest.spyOn(promises, "readFile").mockResolvedValue(
+      JSON.stringify([
+        {
+          authors: ["Raven Leilani"],
+          dateAdded: "2022-10-01",
+          dateFinished: undefined,
+          dateStarted: undefined,
+          description:
+            "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
+          isbn: "9780385696005",
+          language: "en",
+          link: "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
+          pageCount: 240,
+          printType: "BOOK",
+          publishedDate: "2020-08-04",
+          status: "want to read",
+          thumbnail:
+            "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+          title: "Luster",
+        },
+      ])
+    );
+    const exportVariableSpy = jest.spyOn(core, "exportVariable");
+    const setFailedSpy = jest.spyOn(core, "setFailed");
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementationOnce(() => "my-library.json");
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementation((v) => (v === "timeZone" ? "America/New_York" : ""));
+    Object.defineProperty(github, "context", {
+      value: {
+        payload: {
+          inputs: {
+            bookIsbn: "9780385696005",
+            dateStarted: "2022-10-02",
+          },
+        },
+      },
+    });
+    await read();
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(
+      1,
+      "BookStatus",
+      "started"
+    );
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(2, "BookTitle", "Luster");
+    expect(setFailedSpy).not.toHaveBeenCalled();
+    expect(returnWriteFile.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        "my-library.json",
+        [
+          {
+            "authors": [
+              "Raven Leilani",
+            ],
+            "dateAdded": undefined,
+            "dateFinished": undefined,
+            "dateStarted": "2022-10-02",
+            "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
+            "isbn": "9780385696005",
+            "language": "en",
+            "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
+            "pageCount": 240,
+            "printType": "BOOK",
+            "publishedDate": "2020-08-04",
+            "status": "started",
+            "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+            "title": "Luster",
+          },
+        ],
+      ]
+    `);
+  });
+
+  test("finished", async () => {
+    const exportVariableSpy = jest.spyOn(core, "exportVariable");
+    const setFailedSpy = jest.spyOn(core, "setFailed");
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementationOnce(() => "my-library.json");
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementation((v) => (v === "timeZone" ? "America/New_York" : ""));
+    Object.defineProperty(github, "context", {
+      value: {
+        payload: {
+          inputs: {
+            bookIsbn: "9780385696005",
+            dateFinished: "2022-10-03",
+          },
+        },
+      },
+    });
+    await read();
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(
+      1,
+      "BookStatus",
+      "finished"
+    );
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(2, "BookTitle", "Luster");
+
+    expect(exportVariableSpy).toHaveBeenNthCalledWith(
+      3,
+      "BookThumbOutput",
+      "book-9780385696005.png"
+    );
+    expect(setFailedSpy).not.toHaveBeenCalled();
+    expect(returnWriteFile.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        "my-library.json",
+        [
+          {
+            "authors": [
+              "Raven Leilani",
+            ],
+            "dateAdded": undefined,
+            "dateFinished": "2022-10-03",
+            "dateStarted": undefined,
+            "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
+            "isbn": "9780385696005",
+            "language": "en",
+            "link": "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
+            "pageCount": 240,
+            "printType": "BOOK",
+            "publishedDate": "2020-08-04",
+            "status": "finished",
+            "thumbnail": "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+            "title": "Luster",
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -142,7 +142,7 @@ describe("index", () => {
             ],
             "dateAdded": undefined,
             "dateFinished": "2021-09-30",
-            "dateStarted": undefined,
+            "dateStarted": "2021-09-26",
             "description": "NEW YORK TIMES BESTSELLER",
             "isbn": "9780525620792",
             "language": "en",
@@ -576,7 +576,7 @@ describe("workflow", () => {
     `);
   });
 
-  test("started", async () => {
+  test("added to started", async () => {
     jest.spyOn(promises, "readFile").mockResolvedValue(
       JSON.stringify([
         {
@@ -604,9 +604,6 @@ describe("workflow", () => {
     jest
       .spyOn(core, "getInput")
       .mockImplementationOnce(() => "my-library.json");
-    jest
-      .spyOn(core, "getInput")
-      .mockImplementation((v) => (v === "timeZone" ? "America/New_York" : ""));
     Object.defineProperty(github, "context", {
       value: {
         payload: {
@@ -633,7 +630,7 @@ describe("workflow", () => {
             "authors": [
               "Raven Leilani",
             ],
-            "dateAdded": undefined,
+            "dateAdded": "2022-10-01",
             "dateFinished": undefined,
             "dateStarted": "2022-10-02",
             "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
@@ -652,15 +649,34 @@ describe("workflow", () => {
     `);
   });
 
-  test("finished", async () => {
+  test("started to finished", async () => {
+    jest.spyOn(promises, "readFile").mockResolvedValue(
+      JSON.stringify([
+        {
+          authors: ["Raven Leilani"],
+          dateAdded: "2022-10-01",
+          dateFinished: undefined,
+          dateStarted: "2022-10-02",
+          description:
+            "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
+          isbn: "9780385696005",
+          language: "en",
+          link: "https://books.google.com/books/about/Luster.html?hl=&id=eJ06zQEACAAJ",
+          pageCount: 240,
+          printType: "BOOK",
+          publishedDate: "2020-08-04",
+          status: "started",
+          thumbnail:
+            "https://books.google.com/books/content?id=eJ06zQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+          title: "Luster",
+        },
+      ])
+    );
     const exportVariableSpy = jest.spyOn(core, "exportVariable");
     const setFailedSpy = jest.spyOn(core, "setFailed");
     jest
       .spyOn(core, "getInput")
       .mockImplementationOnce(() => "my-library.json");
-    jest
-      .spyOn(core, "getInput")
-      .mockImplementation((v) => (v === "timeZone" ? "America/New_York" : ""));
     Object.defineProperty(github, "context", {
       value: {
         payload: {
@@ -678,12 +694,6 @@ describe("workflow", () => {
       "finished"
     );
     expect(exportVariableSpy).toHaveBeenNthCalledWith(2, "BookTitle", "Luster");
-
-    expect(exportVariableSpy).toHaveBeenNthCalledWith(
-      3,
-      "BookThumbOutput",
-      "book-9780385696005.png"
-    );
     expect(setFailedSpy).not.toHaveBeenCalled();
     expect(returnWriteFile.mock.calls[0]).toMatchInlineSnapshot(`
       [
@@ -693,9 +703,9 @@ describe("workflow", () => {
             "authors": [
               "Raven Leilani",
             ],
-            "dateAdded": undefined,
+            "dateAdded": "2022-10-01",
             "dateFinished": "2022-10-03",
-            "dateStarted": undefined,
+            "dateStarted": "2022-10-02",
             "description": "Sharp, comic, disruptive, tender, Raven Leilani's debut novel, Luster, sees a young black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties--sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage--with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only black woman who young Akila knows. Razor sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make her sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
             "isbn": "9780385696005",
             "language": "en",

--- a/src/checkout-book.ts
+++ b/src/checkout-book.ts
@@ -3,7 +3,7 @@ import returnReadFile from "./read-file";
 import { exportVariable } from "@actions/core";
 import { Dates } from ".";
 
-export async function finishedBook({
+export async function checkOutBook({
   fileName,
   bookIsbn,
   dates,
@@ -45,9 +45,12 @@ export async function updateBook({
   return currentBooks.reduce((arr: CleanBook[], book) => {
     if (book.isbn === bookIsbn) {
       exportVariable("BookTitle", book.title);
-      book.dateFinished = dates.dateFinished;
-      book.status = bookStatus;
-      if (notes || book.notes) book.notes = notes || book.notes;
+      book = {
+        ...book,
+        ...dates,
+        status: bookStatus,
+        ...((notes || book.notes) && { notes: notes || book.notes }),
+      };
     }
     arr.push(book);
     return arr;

--- a/src/checkout-book.ts
+++ b/src/checkout-book.ts
@@ -47,9 +47,11 @@ export async function updateBook({
       exportVariable("BookTitle", book.title);
       book = {
         ...book,
-        ...dates,
+        dateAdded: book.dateAdded || dates.dateAdded,
+        dateStarted: book.dateStarted || dates.dateStarted,
+        dateFinished: book.dateFinished || dates.dateFinished,
         status: bookStatus,
-        ...((notes || book.notes) && { notes: notes || book.notes }),
+        ...(notes && { notes }),
       };
     }
     arr.push(book);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import isbn from "node-isbn";
 import returnWriteFile from "./write-file";
 import getBook from "./get-book";
 import { isDate } from "./utils";
-import { finishedBook } from "./finished-book";
+import { checkOutBook } from "./checkout-book";
 
 export type Dates = {
   dateAdded: string | undefined;
@@ -54,7 +54,7 @@ export async function read() {
     exportVariable("BookStatus", bookStatus);
 
     // Check if book already exists in library
-    const bookExists = await finishedBook({
+    const bookExists = await checkOutBook({
       fileName,
       bookIsbn,
       dates,


### PR DESCRIPTION
Previously, it was not possible to update `dateStarted` or `dateAdded` of a book that's already in the library.