### PR TITLE
Improve 401 error message from node-isbn

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14171,15 +14171,14 @@ async function addBook(options, book, fileName) {
 
 async function getBook(options) {
     const { bookIsbn, providers, fileName } = options;
-    try {
-        const book = (await node_isbn_default().provider(providers).resolve(bookIsbn));
-        (0,core.exportVariable)("BookTitle", book.title);
-        const books = (await addBook(options, book, fileName));
-        return books;
-    }
-    catch (error) {
-        throw new Error(error.message);
-    }
+    const book = await node_isbn_default().provider(providers)
+        .resolve(bookIsbn)
+        .catch((error) => {
+        throw new Error(`Book (${bookIsbn}) not found. ${error.message}`);
+    });
+    (0,core.exportVariable)("BookTitle", book.title);
+    const books = (await addBook(options, book, fileName));
+    return books;
 }
 
 ;// CONCATENATED MODULE: ./src/checkout-book.ts

--- a/src/__tests__/get-book.test.ts
+++ b/src/__tests__/get-book.test.ts
@@ -55,7 +55,9 @@ describe("getBook", () => {
     ).toMatchSnapshot();
   });
   test("fails", async () => {
-    jest.spyOn(isbn, "resolve").mockRejectedValue({ message: "Error!" });
+    jest
+      .spyOn(isbn, "resolve")
+      .mockRejectedValue(new Error("Request failed with status code 401"));
     await expect(
       getBook({
         dates: {
@@ -68,6 +70,8 @@ describe("getBook", () => {
         bookStatus: "finished",
         fileName: "_data/read.json",
       })
-    ).rejects.toMatchInlineSnapshot(`[Error: Error!]`);
+    ).rejects.toMatchInlineSnapshot(
+      `[Error: Book (9780525658184) not found. Request failed with status code 401]`
+    );
   });
 });

--- a/src/get-book.ts
+++ b/src/get-book.ts
@@ -44,12 +44,13 @@ export default async function getBook(
   options: BookParams
 ): Promise<CleanBook[]> {
   const { bookIsbn, providers, fileName } = options;
-  try {
-    const book = (await isbn.provider(providers).resolve(bookIsbn)) as Book;
-    exportVariable("BookTitle", book.title);
-    const books = (await addBook(options, book, fileName)) as CleanBook[];
-    return books;
-  } catch (error) {
-    throw new Error(error.message);
-  }
+  const book: Book = await isbn
+    .provider(providers)
+    .resolve(bookIsbn)
+    .catch((error: Error) => {
+      throw new Error(`Book (${bookIsbn}) not found. ${error.message}`);
+    });
+  exportVariable("BookTitle", book.title);
+  const books = (await addBook(options, book, fileName)) as CleanBook[];
+  return books;
 }


### PR DESCRIPTION
Adds explicit message that the book was not found in addition to the 401 error returned from node-isbn.

fixes #107 