### PR TITLE
Grant the action permission to write to the repository

### DIFF
--- a/.github/workflows/read.yml
+++ b/.github/workflows/read.yml
@@ -1,6 +1,11 @@
 name: Read
 run-name: Book (${{ inputs.bookIsbn }})
 
+# Grant the action permission to write to the repository
+permissions:
+  contents: write
+
+# Trigger the action
 on:
   workflow_dispatch:
     inputs:
@@ -37,6 +42,7 @@ on:
         description: Date you finished the book (YYYY-MM-DD). Optional.
         type: string
 
+# Set up the steps to run the action
 jobs:
   update_library:
     runs-on: macOS-latest

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ To use this action, create a new workflow in `.github/workflows` and modify it a
 name: Read
 run-name: Book (${{ inputs.bookIsbn }})
 
+# Grant the action permission to write to the repository
+permissions:
+  contents: write
+
+# Trigger the action
 on:
   workflow_dispatch:
     inputs:
@@ -62,6 +67,7 @@ on:
         description: Date you finished the book (YYYY-MM-DD). Optional.
         type: string
 
+# Set up the steps to run the action
 jobs:
   update_library:
     runs-on: macOS-latest


### PR DESCRIPTION
Adds `permissions` to sample action to allow the action to write to the repository. Also, add some comments to the sample action.

Fixes #106 