### PR TITLE
Set `nowReading` output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,3 +25,6 @@ inputs:
     default: title,pageCount,authors,description,thumbnail
   thumbnail-width:
     description: The width of the thumbnail image (for books sourced from Google Books). The default size is 128.
+outputs:
+  nowReading:
+    description: The book that is currently being read.

--- a/dist/index.js
+++ b/dist/index.js
@@ -35665,6 +35665,9 @@ async function read() {
             const newBook = await getBook(bookParams);
             library.push(newBook);
             (0,core.exportVariable)(`BookTitle`, newBook.title);
+            if (bookStatus === "started") {
+                (0,core.setOutput)("nowReading", newBook);
+            }
             if (newBook.thumbnail) {
                 (0,core.exportVariable)(`BookThumbOutput`, `book-${newBook.isbn}.png`);
                 (0,core.exportVariable)(`BookThumb`, newBook.thumbnail);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -28,6 +28,7 @@ jest.mock("@actions/core", () => {
     exportVariable: jest.fn(),
     getInput: jest.fn(),
     warning: jest.fn(),
+    setOutput: jest.fn(),
     summary: {
       addRaw: () => ({
         write: jest.fn(),
@@ -58,6 +59,7 @@ describe("index", () => {
   test("works, started a new book", async () => {
     const exportVariableSpy = jest.spyOn(core, "exportVariable");
     const setFailedSpy = jest.spyOn(core, "setFailed");
+    const setOutputSpy = jest.spyOn(core, "setOutput");
     Object.defineProperty(github, "context", {
       value: {
         payload: {
@@ -70,38 +72,64 @@ describe("index", () => {
     });
     await read();
     expect(exportVariableSpy.mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          "BookStatus",
-          "started",
-        ],
-        [
-          "BookNeedsReview",
-          true,
-        ],
-        [
-          "BookMissingMetadata",
-          "pageCount",
-        ],
-        [
-          "BookIsbn",
-          "9780385696005",
-        ],
-        [
-          "BookTitle",
-          "Luster",
-        ],
-        [
-          "BookThumbOutput",
-          "book-9780385696005.png",
-        ],
-        [
-          "BookThumb",
-          "https://books.google.com/books/content?id=NFeTEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-        ],
-      ]
-    `);
+[
+  [
+    "BookStatus",
+    "started",
+  ],
+  [
+    "BookNeedsReview",
+    true,
+  ],
+  [
+    "BookMissingMetadata",
+    "pageCount",
+  ],
+  [
+    "BookIsbn",
+    "9780385696005",
+  ],
+  [
+    "BookTitle",
+    "Luster",
+  ],
+  [
+    "BookThumbOutput",
+    "book-9780385696005.png",
+  ],
+  [
+    "BookThumb",
+    "https://books.google.com/books/content?id=NFeTEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+  ],
+]
+`);
     expect(setFailedSpy).not.toHaveBeenCalled();
+    expect(setOutputSpy.mock.calls[0]).toMatchInlineSnapshot(`
+[
+  "nowReading",
+  {
+    "authors": [
+      "Raven Leilani",
+    ],
+    "categories": [
+      "Fiction",
+    ],
+    "dateAdded": undefined,
+    "dateFinished": undefined,
+    "dateStarted": "2022-01-02",
+    "description": "NEW YORK TIMES BESTSELLER Winner of the 2020 Center for Fiction First Novel Prize Winner of the 2020 National Book Critics Circle's John Leonard Prize for Best First Book Winner of the 2020 Kirkus Prize for Fiction Winner of the 2021 Dylan Thomas Prize Finalist for the 2021 PEN/Hemingway Award for Best First Novel Longlisted for the 2021 Andrew Carnegie Medal for Excellence in Fiction Longlisted for the 2021 PEN/Jean Stein Book Award Longlisted for the 2021 Women's Prize for Fiction A New York Times Notable Book of the Year Named Best Book of the Year by O: the Oprah Magazine, Vanity Fair, Los Angeles Times, Town and Country, Amazon, Indigo, NPR, Harper’s Bazaar, Kirkus Reviews, Marie Claire, Good Housekeeping Sharp, comic, disruptive, and tender, Luster sees a young Black woman fall into art and someone else's open marriage. Edie is stumbling her way through her twenties—sharing a subpar apartment in Bushwick, clocking in and out of her admin job, making a series of inappropriate sexual choices. She's also, secretly, haltingly, figuring her way into life as an artist. And then she meets Eric, a digital archivist with a family in New Jersey, including an autopsist wife who has agreed to an open marriage—with rules. As if navigating the constantly shifting landscapes of contemporary sexual manners and racial politics weren't hard enough, Edie finds herself unemployed and falling into Eric's family life, his home. She becomes a hesitant friend to his wife and a de facto role model to his adopted daughter. Edie is the only Black woman who young Akila knows. Razor-sharp, darkly comic, sexually charged, socially disruptive, Luster is a portrait of a young woman trying to make sense of her life in a tumultuous era. It is also a haunting, aching description of how hard it is to believe in your own talent and the unexpected influences that bring us into ourselves along the way.",
+    "isbn": "9780385696005",
+    "language": "en",
+    "link": "https://books.google.com/books/about/Luster.html?hl=&id=NFeTEAAAQBAJ",
+    "pageCount": 0,
+    "printType": "BOOK",
+    "publishedDate": "2020-08-04",
+    "status": "started",
+    "thumbnail": "https://books.google.com/books/content?id=NFeTEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+    "title": "Luster",
+  },
+]
+`);
     expect(returnWriteFile.mock.calls[0]).toMatchInlineSnapshot(`
 [
   "my-library.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { exportVariable, getInput, setFailed, summary } from "@actions/core";
+import {
+  exportVariable,
+  getInput,
+  setFailed,
+  setOutput,
+  summary,
+} from "@actions/core";
 import * as github from "@actions/github";
 import isbn from "node-isbn";
 import returnWriteFile from "./write-file";
@@ -97,6 +103,11 @@ export async function read() {
       const newBook = await getBook(bookParams);
       library.push(newBook);
       exportVariable(`BookTitle`, newBook.title);
+
+      if (bookStatus === "started") {
+        setOutput("nowReading", newBook);
+      }
+
       if (newBook.thumbnail) {
         exportVariable(`BookThumbOutput`, `book-${newBook.isbn}.png`);
         exportVariable(`BookThumb`, newBook.thumbnail);


### PR DESCRIPTION
Sets output parameter `nowReading` when you start a new book so that you have access the book's metadata object in the workflow.